### PR TITLE
support dns validation

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,38 @@
 hash: e42e3034490724160103db466e5ad71bd6deabdba65109f5a09ebb9651d5209a
-updated: 2017-10-20T18:56:22.73912582+09:00
+updated: 2018-06-15T18:42:04.511162+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 1e7792b681d9bc32eff919999321b2589e891688
+  version: 2fa5290a6a8f6a664f2dab5337d5f64d0cfd8f68
   subpackages:
   - aws
   - aws/awserr
   - aws/awsutil
   - aws/client
   - aws/client/metadata
+  - aws/corehandlers
   - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/csm
+  - aws/defaults
+  - aws/ec2metadata
   - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/sdkio
+  - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
   - private/protocol/json/jsonutil
   - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
   - private/protocol/rest
+  - private/protocol/xml/xmlutil
   - service/acm
+  - service/sts
 - name: github.com/go-ini/ini
   version: 20b96f641a5ea98f2f8619ff4f3e061cff4833bd
 - name: github.com/jmespath/go-jmespath

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: e42e3034490724160103db466e5ad71bd6deabdba65109f5a09ebb9651d5209a
-updated: 2018-06-15T18:42:04.511162+09:00
+updated: 2018-06-18T18:43:46.598425+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 2fa5290a6a8f6a664f2dab5337d5f64d0cfd8f68
+  version: bfc1a07cf158c30c41a3eefba8aae043d0bb5bff
   subpackages:
   - aws
   - aws/awserr

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func ValidateCertificate(ctx context.Context, myacm *acm.ACM, arn string) (bool,
 			if err != nil {
 				continue
 			}
-			if serial == *cert.Serial {
+			if cert.Serial != nil && serial == *cert.Serial {
 				ok = true
 				break
 			}

--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ var myClient = &http.Client{
 	},
 }
 
+// GetSerialNumber gets the serial number of tls certification.
 func GetSerialNumber(u string) (string, error) {
 	resp, err := myClient.Get(u)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 	}
 }
 
+// GetValidationDomains returns the domains that the checker validates.
 func GetValidationDomains(s string) []string {
 	switch {
 	case strings.HasPrefix(s, "www."):

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/acm/acmiface"
 )
 
 func main() {
@@ -58,7 +59,7 @@ func main() {
 }
 
 // ValidateCertificate validates the certificate.
-func ValidateCertificate(ctx context.Context, myacm *acm.ACM, arn string) (bool, error) {
+func ValidateCertificate(ctx context.Context, myacm acmiface.ACMAPI, arn string) (bool, error) {
 	input := &acm.DescribeCertificateInput{
 		CertificateArn: aws.String(arn),
 	}
@@ -75,7 +76,7 @@ func ValidateCertificate(ctx context.Context, myacm *acm.ACM, arn string) (bool,
 				return false, errors.New("validation method is missing")
 			}
 			switch *opt.ValidationMethod {
-			case "DNS":
+			case acm.ValidationMethodDns:
 				record := opt.ResourceRecord
 				v, err := lookup(ctx, *record.Type, *record.Name)
 				if err != nil {
@@ -87,7 +88,7 @@ func ValidateCertificate(ctx context.Context, myacm *acm.ACM, arn string) (bool,
 					log.Printf("failed to validate %s", *opt.DomainName)
 				}
 
-			case "EMAIL":
+			case acm.ValidationMethodEmail:
 				domains := GetValidationDomains(*opt.DomainName)
 				ok := false
 				for _, d := range domains {

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -9,6 +10,11 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/acm"
+	"github.com/aws/aws-sdk-go/service/acm/acmiface"
 )
 
 func TestGetValidationDomains(t *testing.T) {
@@ -71,5 +77,37 @@ func TestGetSerialNumber(t *testing.T) {
 	want := "30:83:02:84:c2:c6:ad:1f:90:be:64:2f:a7:00:14:eb"
 	if !strings.EqualFold(serial, want) {
 		t.Errorf("want %s, got %s", want, serial)
+	}
+}
+
+type mockACMClient struct {
+	acmiface.ACMAPI
+}
+
+func (m *mockACMClient) DescribeCertificateWithContext(ctx aws.Context, input *acm.DescribeCertificateInput, opt ...request.Option) (*acm.DescribeCertificateOutput, error) {
+	return &acm.DescribeCertificateOutput{
+		Certificate: &acm.CertificateDetail{
+			DomainValidationOptions: []*acm.DomainValidation{
+				{
+					ValidationMethod: aws.String(acm.ValidationMethodDns),
+					ResourceRecord: &acm.ResourceRecord{
+						Type:  aws.String(acm.RecordTypeCname),
+						Name:  aws.String("loopback-cname.shogo82148.com."),
+						Value: aws.String("loopback.shogo82148.com."),
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func TestValidateCertificate_DNS(t *testing.T) {
+	myacm := &mockACMClient{}
+	ok, err := ValidateCertificate(context.Background(), myacm, "arn:aws:acm:ap-northeast-1:123456789012:certificate/00000000-0000-0000-0000-000000000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Error("want ok, got not no ok")
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,15 @@
 package main
 
-import "testing"
-import "sort"
-import "reflect"
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
 
 func TestGetValidationDomains(t *testing.T) {
 	cases := []struct {
@@ -43,5 +50,26 @@ func TestGetValidationDomains(t *testing.T) {
 		if !reflect.DeepEqual(o, c.output) {
 			t.Errorf("want %v, got %v", c.output, o)
 		}
+	}
+}
+
+func TestGetSerialNumber(t *testing.T) {
+	myClient.Transport = &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Hello, client")
+	}))
+	defer ts.Close()
+
+	serial, err := GetSerialNumber(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "30:83:02:84:c2:c6:ad:1f:90:be:64:2f:a7:00:14:eb"
+	if !strings.EqualFold(serial, want) {
+		t.Errorf("want %s, got %s", want, serial)
 	}
 }


### PR DESCRIPTION
new validation method is now available.

- [DNS to Validate Domain Ownership](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-validate-dns.html)
